### PR TITLE
Run zunit in GitHub workflow

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -4,12 +4,6 @@ on:
   push:
 
 jobs:
-  shellcheck:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - run: shellcheck -- bin/* *.sh git_template/hooks/* bash_aliases
-
   actionlint:
     runs-on: ubuntu-latest
     steps:
@@ -19,3 +13,22 @@ jobs:
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
           ./actionlint -color
         shell: bash
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: shellcheck -- bin/* *.sh git_template/hooks/* bash_aliases
+
+  zunit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: sudo apt install -y zsh
+      - run: make install_zunit
+      - run: |
+          # Make zunit and revolver available in the PATH
+          export PATH="./bin:$PATH"
+          # Fix for revolver to make it work in a non interactive shell
+          export TERM="dumb"
+          zunit

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-DIR="${HOME}/.dotfiles"
 VIM_VUNDLE_DIR=~/.vim/bundle/Vundle.vim
 TMUX_PLUGIN_MANAGER_DIR=~/.tmux/plugins/tpm
 ZSH_PATH=$(shell which zsh)
@@ -20,8 +19,8 @@ install_brew_packages: installed_brew
 
 .PHONY = install_composer
 install_composer: installed_php
-	sh $(DIR)/bin/install-composer.sh
-	mv composer.phar $(DIR)/bin/composer
+	sh $(CURDIR)/bin/install-composer.sh
+	mv composer.phar $(CURDIR)/bin/composer
 
 .PHONY = install_composer_git_merge_driver
 install_composer_git_merge_driver: installed_composer
@@ -42,30 +41,33 @@ install_yarn: installed_curl
 
 .PHONY = configure_bash
 configure_bash: installed_bash
-	ln -nsf $(DIR)/bash_aliases ~/.bash_aliases
+	ln -nsf $(CURDIR)/bash_aliases ~/.bash_aliases
 
 .PHONY = symlinks
 symlinks:
+	# When the repo isn't checkout in ~/.dotfiles, create a symlink to it. This allows me to hard code ~/.dotfiles in
+	# config files. E.g. in gitconfig.
+	if [ ! -d ~/.dotfiles ]; then ln -nsf $(CURDIR) ~/.dotfiles; fi
 	mkdir -p ~/.agents
-	ln -nsf $(DIR)/agents/AGENTS_personal.md ~/.agents/AGENTS.md
-	ln -nsf $(DIR)/agents/skills ~/.agents/skills
-	ln -nsf $(DIR)/gitconfig ~/.gitconfig
+	ln -nsf $(CURDIR)/agents/AGENTS_personal.md ~/.agents/AGENTS.md
+	ln -nsf $(CURDIR)/agents/skills ~/.agents/skills
+	ln -nsf $(CURDIR)/gitconfig ~/.gitconfig
 
 bin/antigen.zsh: installed_curl
-	touch $(DIR)/bin/antigen.zsh
-	curl -L git.io/antigen-nightly > $(DIR)/bin/antigen.zsh
+	touch $(CURDIR)/bin/antigen.zsh
+	curl -L git.io/antigen-nightly > $(CURDIR)/bin/antigen.zsh
 
 .PHONY = configure_zsh
 configure_zsh: installed_zsh bin/antigen.zsh
-	ln -nsf $(DIR)/zshrc ~/.zshrc
+	ln -nsf $(CURDIR)/zshrc ~/.zshrc
 	echo $(ZSH_PATH) | sudo tee -a /etc/shells > /dev/null
 	sudo chsh -s $(ZSH_PATH)
 
 .PHONY = install_vim_symlinks
 install_vim_symlinks:
-	ln -nsf $(DIR)/ctags ~/.ctags
-	ln -nsf $(DIR)/vim ~/.vim
-	ln -nsf $(DIR)/ideavimrc ~/.ideavimrc
+	ln -nsf $(CURDIR)/ctags ~/.ctags
+	ln -nsf $(CURDIR)/vim ~/.vim
+	ln -nsf $(CURDIR)/ideavimrc ~/.ideavimrc
 
 .PHONY = install_vim_vundle
 install_vim_vundle: installed_git
@@ -80,8 +82,8 @@ configure_vim: installed_vim install_vim_symlinks install_vim_vundle install_vim
 
 .PHONY = install_tmux_symlinks
 install_tmux_symlinks:
-	ln -nsf $(DIR)/tmux.conf ~/.tmux.conf
-	ln -nsf $(DIR)/tmux-themes ~/.tmux-themes
+	ln -nsf $(CURDIR)/tmux.conf ~/.tmux.conf
+	ln -nsf $(CURDIR)/tmux-themes ~/.tmux-themes
 
 .PHONY = install_tmux_plugin_manager
 install_tmux_plugin_manager: installed_git
@@ -96,7 +98,7 @@ configure_tmux: installed_tmux install_tmux_symlinks install_tmux_plugin_manager
 
 .PHONY = configure_theme_switcher
 configure_theme_switcher:
-	ln -nsf $(DIR)/com.martijngastkemper.theme-switcher.plist ~/Library/LaunchAgents/com.martijngastkemper.theme-switcher.plist
+	ln -nsf $(CURDIR)/com.martijngastkemper.theme-switcher.plist ~/Library/LaunchAgents/com.martijngastkemper.theme-switcher.plist
 	launchctl unload ~/Library/LaunchAgents/com.martijngastkemper.theme-switcher.plist
 	launchctl load ~/Library/LaunchAgents/com.martijngastkemper.theme-switcher.plist
 

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,2 +1,4 @@
 antigen.zsh
 composer
+revolver
+zunit

--- a/tests/gcm.zunit
+++ b/tests/gcm.zunit
@@ -4,16 +4,18 @@
 
   load ../gcm.zsh
 
+  # Configure git
+  make symlinks
+  git config --global commit.gpgsign false
+
+  # Create repository
   cd `mktemp -d`
+  git init
 
-  git init --initial-branch="main" .
-
-  git config user.email zunit@martijngastkemper.nl
-  git config commit.gpgsign false
+  # Add a file
   touch file.txt
-
   git add file.txt
-  git commit --allow-empty --no-verify --message="test commit"
+  git commit --no-verify --message="test commit"
 
 }
 


### PR DESCRIPTION
- Remove hard coded ".dotfiles" directory from Makefile, this makes it possible to use make in the workflow.
- Add a fallback to `~/.dotfiles` to keep the option to reference it. E.g. in `gitconfig`.