### PR TITLE
Remove tmux-themes symlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,6 @@ configure_vim: installed_vim install_vim_symlinks install_vim_vundle install_vim
 .PHONY = install_tmux_symlinks
 install_tmux_symlinks:
 	ln -nsf $(CURDIR)/tmux.conf ~/.tmux.conf
-	ln -nsf $(CURDIR)/tmux-themes ~/.tmux-themes
 
 .PHONY = install_tmux_plugin_manager
 install_tmux_plugin_manager: installed_git

--- a/bin/dark
+++ b/bin/dark
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-/opt/homebrew/bin/tmux source-file ~/.tmux-themes/dark.conf
+/opt/homebrew/bin/tmux source-file ~/.dotfiles/tmux-themes/dark.conf
 

--- a/bin/light
+++ b/bin/light
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-/opt/homebrew/bin/tmux source-file ~/.tmux-themes/light.conf
+/opt/homebrew/bin/tmux source-file ~/.dotfiles/tmux-themes/light.conf

--- a/tmux.conf
+++ b/tmux.conf
@@ -47,7 +47,7 @@ bind-key -T copy-mode-vi 'C-\' select-pane '-l'
 #  Theme
 ###########################
 
-source-file ~/.tmux-themes/dark.conf
+source-file ~/.dotfiles/tmux-themes/dark.conf
 
 ###########################
 #  Status bar


### PR DESCRIPTION
Since 5695a0d2b826688b0ed453b5f8c3cf41d30c6e9d the path "~/.dotfiles" always exists. Making it possible for the tmux configuration to rely on it.