### PR TITLE
Use newsyslog to manage the log files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,8 +129,15 @@ configure_ghostty:
 	ln -nsf $(CURDIR)/ghostty/config ~/.config/ghostty/config
 	ln -nsf $(CURDIR)/ghostty/themes ~/.config/ghostty/themes
 
+.PHONY: configure_launchd_logs
+configure_launchd_logs:
+	mkdir -p ~/Library/Logs/com.martijngastkemper
+	touch ~/Library/Logs/com.martijngastkemper/theme-switcher.out.log ~/Library/Logs/com.martijngastkemper/theme-switcher.err.log
+	touch ~/Library/Logs/com.martijngastkemper/opencode-update.out.log ~/Library/Logs/com.martijngastkemper/opencode-update.err.log
+	sudo ln -nsf $(CURDIR)/newsyslog.conf /etc/newsyslog.d/com.martijngastkemper.conf
+
 .PHONY: configure_macos
-configure_macos: configure_theme_switcher install_opencode_update_agent
+configure_macos: configure_theme_switcher install_opencode_update_agent configure_launchd_logs
 	@sh macos_config.sh;\
 	exit $$?
 

--- a/com.martijngastkemper.opencode-update.plist
+++ b/com.martijngastkemper.opencode-update.plist
@@ -20,9 +20,9 @@
   <key>RunAtLoad</key>
   <true/>
   <key>StandardErrorPath</key>
-  <string>/tmp/com.martijngastkemper.opencode-update.err</string>
+  <string>~/Library/Logs/com.martijngastkemper/opencode-update.err.log</string>
   <key>StandardOutPath</key>
-  <string>/tmp/com.martijngastkemper.opencode-update.out</string>
+  <string>~/Library/Logs/com.martijngastkemper/opencode-update.out.log</string>
 </dict>
 </plist>
 

--- a/com.martijngastkemper.theme-switcher.plist
+++ b/com.martijngastkemper.theme-switcher.plist
@@ -15,8 +15,8 @@
   <key>StartInterval</key>
   <integer>5</integer>
   <key>StandardOutPath</key>
-  <string>/tmp/theme-switcher.stdout.log</string>
+  <string>~/Library/Logs/com.martijngastkemper/theme-switcher.out.log</string>
   <key>StandardErrorPath</key>
-  <string>/tmp/theme-switcher.stderr.log</string>
+  <string>~/Library/Logs/com.martijngastkemper/theme-switcher.err.log</string>
 </dict>
 </plist>

--- a/newsyslog.conf
+++ b/newsyslog.conf
@@ -1,0 +1,5 @@
+# logfilename          [owner:group]    mode count size when  flags [/pid_file] [sig_num]
+~/Library/Logs/com.martijngastkemper/theme-switcher.out.log                     644  5    100  *       N
+~/Library/Logs/com.martijngastkemper/theme-switcher.err.log                     644  5    100  *       N
+~/Library/Logs/com.martijngastkemper/opencode-update.out.log                    644  5    100  *       N
+~/Library/Logs/com.martijngastkemper/opencode-update.err.log                    644  5    100  *       N


### PR DESCRIPTION
newsyslog is the MacOS utility that can clean up and rotate log files. This also make the log file appear in Console.