### PR TITLE
Fix launchd proces loging

### DIFF
--- a/com.martijngastkemper.opencode-update.plist
+++ b/com.martijngastkemper.opencode-update.plist
@@ -8,7 +8,7 @@
     <array>
       <string>/bin/sh</string>
       <string>-c</string>
-      <string>sh ~/.dotfiles/bin/check_opencode_update</string>
+      <string>sh ~/.dotfiles/bin/check_opencode_update >>$HOME/Library/Logs/com.martijngastkemper/opencode-update.out.log 2>>$HOME/Library/Logs/com.martijngastkemper/opencode-update.err.log</string>
     </array>
   <key>StartCalendarInterval</key>
   <dict>
@@ -19,10 +19,6 @@
   </dict>
   <key>RunAtLoad</key>
   <true/>
-  <key>StandardErrorPath</key>
-  <string>~/Library/Logs/com.martijngastkemper/opencode-update.err.log</string>
-  <key>StandardOutPath</key>
-  <string>~/Library/Logs/com.martijngastkemper/opencode-update.out.log</string>
 </dict>
 </plist>
 

--- a/com.martijngastkemper.theme-switcher.plist
+++ b/com.martijngastkemper.theme-switcher.plist
@@ -8,15 +8,11 @@
   <array>
     <string>/bin/sh</string>
     <string>-c</string>
-    <string>sh ~/.dotfiles/bin/macos_switch_theme</string>
+    <string>sh ~/.dotfiles/bin/macos_switch_theme >>$HOME/Library/Logs/com.martijngastkemper/theme-switcher.out.log 2>>$HOME/Library/Logs/com.martijngastkemper/theme-switcher.err.log</string>
   </array>
   <key>RunAtLoad</key>
   <true/>
   <key>StartInterval</key>
   <integer>5</integer>
-  <key>StandardOutPath</key>
-  <string>~/Library/Logs/com.martijngastkemper/theme-switcher.out.log</string>
-  <key>StandardErrorPath</key>
-  <string>~/Library/Logs/com.martijngastkemper/theme-switcher.err.log</string>
 </dict>
 </plist>

--- a/newsyslog.conf
+++ b/newsyslog.conf
@@ -1,5 +1,5 @@
 # logfilename          [owner:group]    mode count size when  flags [/pid_file] [sig_num]
-~/Library/Logs/com.martijngastkemper/theme-switcher.out.log                     644  5    100  *       N
-~/Library/Logs/com.martijngastkemper/theme-switcher.err.log                     644  5    100  *       N
-~/Library/Logs/com.martijngastkemper/opencode-update.out.log                    644  5    100  *       N
-~/Library/Logs/com.martijngastkemper/opencode-update.err.log                    644  5    100  *       N
+/Users/martijngastkemper/Library/Logs/com.martijngastkemper/theme-switcher.out.log                     644  5    100  *       N
+/Users/martijngastkemper/Library/Logs/com.martijngastkemper/theme-switcher.err.log                     644  5    100  *       N
+/Users/martijngastkemper/Library/Logs/com.martijngastkemper/opencode-update.out.log                    644  5    100  *       N
+/Users/martijngastkemper/Library/Logs/com.martijngastkemper/opencode-update.err.log                    644  5    100  *       N


### PR DESCRIPTION
launchd and newsyslog do not expand the tilde. This fixes it, although I was not able to find a solution for the hard coded username in newsyslog.conf.